### PR TITLE
Document pretender workaround of percy route

### DIFF
--- a/docs/clients/javascript/ember.md
+++ b/docs/clients/javascript/ember.md
@@ -131,6 +131,9 @@ See our [GitHub integration](/docs/learn/github-integration) docs for more info.
   * Mirage blocks network requests by default. You need to add `this.passthrough('/_percy/**');` to your mirage routes to whitelist Percy's internal requests that are made in tests. Make sure to add it to the **top** of your routes to avoid being affected by `this.namespace` changes.
   * Also, Mirage's `passthrough` requires jQuery > 2.x. If you are running Ember 2.3 or greater, simply remove the `jquery` line from your `bower.json` (Ember 2.3 and greater will pull in the correct jQuery version). Otherwise, you will need to upgrade your jQuery version for Mirage.
 
+* **Pretender users**:
+  * Like Mirage, which uses Pretender under the hood, Pretender blocks network requests by default. A passthrough mechanism is also available but the syntax is slightly different. You can add `this.post('/_percy/:param', this.passthrough);` to your Pretender route handlers.
+
 ## Other resources
 
 * EmberScreencasts video: [Introduction to Visual Regression Testing](https://www.emberscreencasts.com/posts/160)


### PR DESCRIPTION
The base Pretender API for route handlers is different than Mirages, so I've documented it here.