### PR TITLE
Remove broken link to "Other" CI service

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,6 @@ Select your CI service to get started:
 * [Codeship](/docs/setup/codeship)
 * [Drone](/docs/setup/drone)
 * [Semaphore](/docs/setup/semaphore)
-* [Other](/docs/setup/other)
 
 ## Clients
 


### PR DESCRIPTION
It looks like the "Other" CI service page doesn't exist anymore. 
![other](https://cloud.githubusercontent.com/assets/1280389/17543416/86f48bfa-5e9e-11e6-800b-4e18f6642619.gif)
This PR removes the link to that broken link.